### PR TITLE
feat: Real activity feed from daily notes

### DIFF
--- a/src/components/mission-control/activity-feed.tsx
+++ b/src/components/mission-control/activity-feed.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { Activity, getAgent, formatRelativeTime } from '@/lib/mission-control-data';
+import { Activity, getAgent, formatRelativeTime, mockAgents } from '@/lib/mission-control-data';
 import { cn } from '@/lib/utils';
 
 interface ActivityFeedProps {
   activities: Activity[];
   maxItems?: number;
+  isLoading?: boolean;
+  onRefresh?: () => void;
+  lastRefresh?: Date | null;
 }
 
 const activityIcons: Record<Activity['type'], string> = {
@@ -17,14 +20,62 @@ const activityIcons: Record<Activity['type'], string> = {
   agent_status: '⚡',
 };
 
-export function ActivityFeed({ activities, maxItems }: ActivityFeedProps) {
+// Fallback agent lookup for activities from daily notes
+function getAgentFallback(agentId: string) {
+  const agent = getAgent(agentId);
+  if (agent) return agent;
+  
+  // Create a fallback for unknown agents
+  return {
+    id: agentId,
+    name: agentId.charAt(0).toUpperCase() + agentId.slice(1),
+    emoji: '🤖',
+    role: 'Agent',
+    status: 'idle' as const,
+    focus: null,
+    lastActive: new Date(),
+    color: 'leo',
+  };
+}
+
+export function ActivityFeed({ activities, maxItems, isLoading, onRefresh, lastRefresh }: ActivityFeedProps) {
   const items = maxItems ? activities.slice(0, maxItems) : activities;
 
   return (
     <div className="space-y-0">
-      {items.map((activity, index) => {
-        const agent = getAgent(activity.agentId);
-        if (!agent) return null;
+      {/* Loading indicator */}
+      {isLoading && (
+        <div className="py-4 px-4 border-b border-border">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <svg
+              className="w-4 h-4 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            <span className="text-xs">Loading activities...</span>
+          </div>
+        </div>
+      )}
+      
+      {/* Last refresh indicator */}
+      {lastRefresh && !isLoading && (
+        <div className="py-2 px-4 border-b border-border bg-muted/30">
+          <p className="font-mono text-[9px] text-muted-foreground uppercase tracking-wider">
+            Updated {formatRelativeTime(lastRefresh)}
+          </p>
+        </div>
+      )}
+      
+      {items.map((activity) => {
+        const agent = getAgentFallback(activity.agentId);
 
         return (
           <div
@@ -59,10 +110,20 @@ export function ActivityFeed({ activities, maxItems }: ActivityFeedProps) {
         );
       })}
       
-      {items.length === 0 && (
-        <p className="text-center py-8 text-sm text-muted-foreground">
-          No recent activity
-        </p>
+      {items.length === 0 && !isLoading && (
+        <div className="text-center py-8">
+          <p className="text-sm text-muted-foreground mb-2">
+            No recent activity
+          </p>
+          {onRefresh && (
+            <button
+              onClick={onRefresh}
+              className="text-xs text-muted-foreground hover:text-foreground underline"
+            >
+              Refresh
+            </button>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Updates the Command Center activity feed to parse real data from the life-data repository's daily notes.

## Changes
- **GitHubDataSource.getActivity()**: Now parses daily notes from `memory/daily/*.md` instead of looking for a non-existent `activity/` directory
- **Activity parsing**: Supports multiple formats:
  - Timestamped entries: `## 14:32` or `## 14:32 - Description`
  - Tagged entries: `- [status_change] Description`
  - Completed items: `- [x] Item` or `- ✅ Item`
  - Regular bullets with keyword detection
- **Agent detection**: Infers agent from content keywords (e.g., 'testing' → murphie)
- **SquadDashboard**: Now fetches activities via data source with proper state management
- **Refresh capability**: Added refresh button and loading states
- **ActivityFeed component**: Shows loading indicator and last refresh timestamp

## Testing
- Builds successfully with `npm run build`
- TypeScript passes with `tsc --noEmit`
- Falls back to mock data when no activities found

Closes #9