### PR TITLE
feat(notes): add list view and enhance note display

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
-import { KanbanBoard } from './kanban-board';
+import { useState } from 'react';
+import { NotesView } from './notes-view';
 import { SquadDashboard } from './mission-control/squad-dashboard';
 import { AppSidebar, NavView } from './app-sidebar';
 import { MobileNav } from './mobile-nav';
@@ -17,15 +17,67 @@ import { MockDataSource } from '@/lib/data-source';
 import type { AgentDetail } from '@/lib/data-source';
 import type { SearchResult } from '@/lib/search';
 
-// Placeholder components for upcoming views
-function ActivityView() {
+type View = 'notes' | 'mission-control';
+
+export function AppShell() {
+  const [view, setView] = useState<View>('notes');
+
   return (
-    <div className="flex flex-1 items-center justify-center p-8">
-      <div className="text-center">
-        <span className="text-6xl mb-4 block">📊</span>
-        <h2 className="font-mono text-lg font-bold tracking-wider uppercase mb-2">Activity</h2>
-        <p className="text-muted-foreground font-mono text-sm">Coming soon...</p>
-      </div>
+    <div className="min-h-screen flex flex-col bg-background">
+      {/* Header with nav */}
+      <header className="sticky top-0 z-50 bg-background border-b border-border">
+        {/* Title bar */}
+        <div className="px-4 py-3 flex justify-between items-center">
+          <div>
+            <h1 className="font-mono text-sm font-bold tracking-[0.25em] uppercase">
+              {view === 'notes' ? 'PLAUD' : 'MISSION'}
+            </h1>
+            <span className="font-mono text-[10px] text-muted-foreground tracking-widest">
+              {view === 'notes' ? 'NOTES' : 'CONTROL'}
+            </span>
+          </div>
+          <ThemeToggle />
+        </div>
+
+        {/* View switcher */}
+        <div className="flex border-t border-border">
+          <button
+            onClick={() => setView('notes')}
+            className={cn(
+              'flex-1 py-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors',
+              'border-b-2',
+              view === 'notes'
+                ? 'border-b-donnie text-foreground'
+                : 'border-b-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <span className={cn('w-2 h-2 inline-block mr-2', view === 'notes' ? 'bg-donnie' : 'bg-muted-foreground')} />
+            Notes
+          </button>
+          <button
+            onClick={() => setView('mission-control')}
+            className={cn(
+              'flex-1 py-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors',
+              'border-b-2',
+              view === 'mission-control'
+                ? 'border-b-raph text-foreground'
+                : 'border-b-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <span className={cn('w-2 h-2 inline-block mr-2', view === 'mission-control' ? 'bg-raph' : 'bg-muted-foreground')} />
+            Mission Control
+          </button>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-hidden">
+        {view === 'notes' ? (
+          <NotesView embedded />
+        ) : (
+          <SquadDashboard />
+        )}
+      </main>
     </div>
   );
 }

--- a/src/components/note-card.tsx
+++ b/src/components/note-card.tsx
@@ -10,6 +10,16 @@ interface NoteCardProps {
   onClick: () => void;
 }
 
+function formatDuration(seconds?: number): string {
+  if (!seconds) return '';
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+  return remainingMins > 0 ? `${hrs}h ${remainingMins}m` : `${hrs}h`;
+}
+
 export function NoteCard({ note, onClick }: NoteCardProps) {
   const {
     attributes,
@@ -26,6 +36,7 @@ export function NoteCard({ note, onClick }: NoteCardProps) {
   };
 
   const pendingTasks = note.actions.filter(a => !a.done).length;
+  const duration = formatDuration(note.duration);
 
   return (
     <div
@@ -42,11 +53,39 @@ export function NoteCard({ note, onClick }: NoteCardProps) {
         isDragging && 'opacity-50 shadow-lg'
       )}
     >
-      <h3 className="text-sm font-medium mb-3 line-clamp-2 leading-snug">
+      <h3 className="text-sm font-medium mb-2 line-clamp-2 leading-snug">
         {note.title}
       </h3>
+      
+      {/* Tags preview */}
+      {note.takeaways.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {note.takeaways.slice(0, 2).map((tag, i) => (
+            <span 
+              key={i}
+              className="font-mono text-[9px] text-muted-foreground uppercase tracking-wider bg-accent/50 px-1.5 py-0.5"
+            >
+              {tag}
+            </span>
+          ))}
+          {note.takeaways.length > 2 && (
+            <span className="font-mono text-[9px] text-muted-foreground">
+              +{note.takeaways.length - 2}
+            </span>
+          )}
+        </div>
+      )}
+      
       <div className="flex justify-between items-center font-mono text-[10px] text-muted-foreground uppercase tracking-wider">
-        <span>{note.date}</span>
+        <div className="flex items-center gap-2">
+          <span>{note.date}</span>
+          {duration && (
+            <>
+              <span className="text-border">•</span>
+              <span>{duration}</span>
+            </>
+          )}
+        </div>
         {pendingTasks > 0 && (
           <span className="bg-raph text-white px-2 py-1 font-bold">
             {pendingTasks}

--- a/src/components/note-detail.tsx
+++ b/src/components/note-detail.tsx
@@ -20,8 +20,20 @@ interface NoteDetailProps {
   onToggleAction: (noteId: string, actionIndex: number) => void;
 }
 
+function formatDuration(seconds?: number): string {
+  if (!seconds) return '';
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+  return remainingMins > 0 ? `${hrs}h ${remainingMins}m` : `${hrs}h`;
+}
+
 export function NoteDetail({ note, open, onClose, onMove, onToggleAction }: NoteDetailProps) {
   if (!note) return null;
+
+  const duration = formatDuration(note.duration);
 
   return (
     <Sheet open={open} onOpenChange={onClose}>
@@ -32,22 +44,35 @@ export function NoteDetail({ note, open, onClose, onMove, onToggleAction }: Note
         {/* Fixed Header */}
         <SheetHeader className="p-4 md:p-6 pb-4 flex-shrink-0 border-b border-border">
           <div className="space-y-2">
-            <Badge
-              className={cn(
-                'font-mono text-[9px] uppercase tracking-widest rounded-none px-2.5 py-1',
-                note.type === 'voice'
-                  ? 'bg-donnie text-white hover:bg-donnie'
-                  : 'bg-mikey text-white hover:bg-mikey'
+            <div className="flex items-center gap-2 flex-wrap">
+              <Badge
+                className={cn(
+                  'font-mono text-[9px] uppercase tracking-widest rounded-none px-2.5 py-1',
+                  note.type === 'voice'
+                    ? 'bg-donnie text-white hover:bg-donnie'
+                    : 'bg-mikey text-white hover:bg-mikey'
+                )}
+              >
+                {note.type}
+              </Badge>
+              {duration && (
+                <Badge variant="outline" className="font-mono text-[9px] uppercase tracking-widest rounded-none px-2.5 py-1">
+                  {duration}
+                </Badge>
               )}
-            >
-              {note.type}
-            </Badge>
+            </div>
             <SheetTitle className="text-lg md:text-xl font-semibold leading-tight text-left">
               {note.title}
             </SheetTitle>
-            <p className="font-mono text-[10px] text-muted-foreground uppercase tracking-wider">
-              {note.date}
-            </p>
+            <div className="flex items-center gap-3 font-mono text-[10px] text-muted-foreground uppercase tracking-wider">
+              <span>{note.date}</span>
+              {note.participants && note.participants.length > 0 && (
+                <>
+                  <span className="text-border">•</span>
+                  <span>{note.participants.join(', ')}</span>
+                </>
+              )}
+            </div>
           </div>
         </SheetHeader>
 
@@ -62,20 +87,23 @@ export function NoteDetail({ note, open, onClose, onMove, onToggleAction }: Note
               <p className="text-sm md:text-[15px] leading-relaxed">{note.synopsis}</p>
             </section>
 
-            {/* Takeaways */}
+            {/* Tags */}
             {note.takeaways.length > 0 && (
               <section>
                 <h4 className="font-mono text-[9px] uppercase tracking-widest text-muted-foreground mb-2 font-bold">
-                  Takeaways
+                  Tags
                 </h4>
-                <ul className="space-y-0">
-                  {note.takeaways.map((t, i) => (
-                    <li key={i} className="py-3 border-b border-border text-sm leading-snug">
-                      <span className="text-muted-foreground mr-2">—</span>
-                      {t}
-                    </li>
+                <div className="flex flex-wrap gap-2">
+                  {note.takeaways.map((tag, i) => (
+                    <Badge
+                      key={i}
+                      variant="outline"
+                      className="font-mono text-[10px] uppercase tracking-widest rounded-none px-2.5 py-1"
+                    >
+                      {tag}
+                    </Badge>
                   ))}
-                </ul>
+                </div>
               </section>
             )}
 

--- a/src/components/note-list.tsx
+++ b/src/components/note-list.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { Note, NoteType, ColumnId } from '@/lib/types';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface NoteListProps {
+  notes: Note[];
+  onNoteClick: (note: Note) => void;
+  typeFilter: NoteType | 'all';
+  columnFilter: ColumnId | 'all';
+}
+
+function formatDuration(seconds?: number): string {
+  if (!seconds) return '';
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+  return remainingMins > 0 ? `${hrs}h ${remainingMins}m` : `${hrs}h`;
+}
+
+function getColumnColor(column: ColumnId): string {
+  switch (column) {
+    case 'inbox': return 'bg-muted-foreground';
+    case 'review': return 'bg-leo';
+    case 'action': return 'bg-raph';
+    case 'done': return 'bg-green-500';
+    default: return 'bg-muted-foreground';
+  }
+}
+
+export function NoteList({ notes, onNoteClick, typeFilter, columnFilter }: NoteListProps) {
+  const filteredNotes = notes.filter(note => {
+    if (typeFilter !== 'all' && note.type !== typeFilter) return false;
+    if (columnFilter !== 'all' && note.column !== columnFilter) return false;
+    return true;
+  });
+
+  // Sort by date descending
+  const sortedNotes = [...filteredNotes].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+
+  if (sortedNotes.length === 0) {
+    return (
+      <div className="p-8 text-center text-muted-foreground">
+        <p className="font-mono text-sm">No notes found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-border">
+      {sortedNotes.map(note => {
+        const pendingTasks = note.actions.filter(a => !a.done).length;
+        
+        return (
+          <div
+            key={note.id}
+            onClick={() => onNoteClick(note)}
+            className={cn(
+              'p-4 cursor-pointer hover:bg-accent/50 transition-colors',
+              'border-l-[3px]',
+              note.type === 'voice' ? 'border-l-donnie' : 'border-l-mikey'
+            )}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                {/* Title */}
+                <h3 className="text-sm font-medium leading-snug mb-1 line-clamp-2">
+                  {note.title}
+                </h3>
+                
+                {/* Synopsis */}
+                <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+                  {note.synopsis}
+                </p>
+                
+                {/* Tags */}
+                {note.takeaways.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mb-2">
+                    {note.takeaways.slice(0, 3).map((tag, i) => (
+                      <Badge
+                        key={i}
+                        variant="outline"
+                        className="font-mono text-[9px] uppercase tracking-wider px-1.5 py-0 h-5"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                    {note.takeaways.length > 3 && (
+                      <span className="text-[10px] text-muted-foreground">
+                        +{note.takeaways.length - 3}
+                      </span>
+                    )}
+                  </div>
+                )}
+                
+                {/* Meta row */}
+                <div className="flex items-center gap-3 font-mono text-[10px] text-muted-foreground uppercase tracking-wider">
+                  <span>{note.date}</span>
+                  {note.duration && (
+                    <>
+                      <span className="text-border">•</span>
+                      <span>{formatDuration(note.duration)}</span>
+                    </>
+                  )}
+                  {note.participants && note.participants.length > 0 && (
+                    <>
+                      <span className="text-border">•</span>
+                      <span>{note.participants.length} participants</span>
+                    </>
+                  )}
+                </div>
+              </div>
+              
+              {/* Right side badges */}
+              <div className="flex flex-col items-end gap-2 flex-shrink-0">
+                {/* Status badge */}
+                <div className={cn(
+                  'w-2 h-2 rounded-full',
+                  getColumnColor(note.column)
+                )} />
+                
+                {/* Task count */}
+                {pendingTasks > 0 && (
+                  <span className="bg-raph text-white text-[10px] px-2 py-0.5 font-mono font-bold">
+                    {pendingTasks}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/notes-view.tsx
+++ b/src/components/notes-view.tsx
@@ -1,0 +1,430 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { Note, NoteType, ColumnId, ViewMode, COLUMNS } from '@/lib/types';
+import { sampleNotes } from '@/lib/data';
+import { KanbanColumn } from './kanban-column';
+import { NoteList } from './note-list';
+import { NoteDetail } from './note-detail';
+import { TaskSidebar } from './task-sidebar';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+// Icons for view toggle
+function KanbanIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="3" y="3" width="5" height="18" rx="1" />
+      <rect x="10" y="3" width="5" height="12" rx="1" />
+      <rect x="17" y="3" width="5" height="8" rx="1" />
+    </svg>
+  );
+}
+
+function ListIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <line x1="8" y1="6" x2="21" y2="6" />
+      <line x1="8" y1="12" x2="21" y2="12" />
+      <line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3.01" y2="6" />
+      <line x1="3" y1="12" x2="3.01" y2="12" />
+      <line x1="3" y1="18" x2="3.01" y2="18" />
+    </svg>
+  );
+}
+
+interface NotesViewProps {
+  embedded?: boolean;
+}
+
+export function NotesView({ embedded }: NotesViewProps) {
+  const [notes, setNotes] = useState<Note[]>(sampleNotes);
+  const [selectedNote, setSelectedNote] = useState<Note | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [taskSheetOpen, setTaskSheetOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('kanban');
+  const [typeFilter, setTypeFilter] = useState<NoteType | 'all'>('all');
+  const [columnFilter, setColumnFilter] = useState<ColumnId | 'all'>('all');
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } })
+  );
+
+  const pendingTaskCount = notes.reduce(
+    (sum, n) => sum + n.actions.filter(a => !a.done).length,
+    0
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+
+    const activeNote = notes.find(n => n.id === active.id);
+    if (!activeNote) return;
+
+    const overColumn = COLUMNS.find(c => c.id === over.id);
+    if (overColumn && activeNote.column !== overColumn.id) {
+      setNotes(prev =>
+        prev.map(n =>
+          n.id === active.id ? { ...n, column: overColumn.id } : n
+        )
+      );
+    }
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over) return;
+
+    const activeNote = notes.find(n => n.id === active.id);
+    if (!activeNote) return;
+
+    const overColumn = COLUMNS.find(c => c.id === over.id);
+    if (overColumn) {
+      setNotes(prev =>
+        prev.map(n =>
+          n.id === active.id ? { ...n, column: overColumn.id } : n
+        )
+      );
+    }
+  };
+
+  const handleMove = (noteId: string, column: ColumnId) => {
+    setNotes(prev =>
+      prev.map(n => (n.id === noteId ? { ...n, column } : n))
+    );
+  };
+
+  const handleToggleAction = (noteId: string, actionIndex: number) => {
+    setNotes(prev =>
+      prev.map(n => {
+        if (n.id !== noteId) return n;
+        const newActions = [...n.actions];
+        newActions[actionIndex] = {
+          ...newActions[actionIndex],
+          done: !newActions[actionIndex].done,
+        };
+        return { ...n, actions: newActions };
+      })
+    );
+  };
+
+  const activeNote = activeId ? notes.find(n => n.id === activeId) : null;
+
+  const renderKanbanRow = (type: NoteType) => {
+    const typeNotes = notes.filter(n => n.type === type);
+    return (
+      <div className="flex gap-3 md:gap-4 p-3 md:p-4 overflow-x-auto snap-x snap-mandatory scrollbar-hide pb-20 md:pb-4">
+        {COLUMNS.map(col => (
+          <KanbanColumn
+            key={`${type}-${col.id}`}
+            id={col.id}
+            label={col.label}
+            notes={typeNotes.filter(n => n.column === col.id)}
+            onNoteClick={setSelectedNote}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  const renderKanbanContent = () => (
+    <>
+      {/* Mobile: Tabs layout */}
+      <div className="lg:hidden h-full flex flex-col">
+        <Tabs defaultValue="voice" className="h-full flex flex-col">
+          <TabsList className="w-full rounded-none border-b border-border bg-transparent h-12 p-0">
+            <TabsTrigger 
+              value="voice" 
+              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-donnie data-[state=active]:bg-transparent font-mono text-xs uppercase tracking-widest h-full"
+            >
+              <span className="w-2 h-2 bg-donnie mr-2" />
+              Voice
+              <span className="ml-2 text-muted-foreground">
+                {notes.filter(n => n.type === 'voice').length}
+              </span>
+            </TabsTrigger>
+            <TabsTrigger 
+              value="meetings"
+              className="flex-1 rounded-none border-b-2 border-transparent data-[state=active]:border-mikey data-[state=active]:bg-transparent font-mono text-xs uppercase tracking-widest h-full"
+            >
+              <span className="w-2 h-2 bg-mikey mr-2" />
+              Meetings
+              <span className="ml-2 text-muted-foreground">
+                {notes.filter(n => n.type === 'meeting').length}
+              </span>
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="voice" className="flex-1 overflow-auto mt-0">
+            {renderKanbanRow('voice')}
+          </TabsContent>
+          <TabsContent value="meetings" className="flex-1 overflow-auto mt-0">
+            {renderKanbanRow('meeting')}
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      {/* Desktop: Stacked sections */}
+      <div className="hidden lg:flex lg:flex-1 lg:flex-col overflow-y-auto">
+        <section className="py-4">
+          <div className="sticky top-0 bg-background z-40 border-b border-border px-5 py-3 flex items-center gap-3">
+            <div className="w-1 h-6 bg-donnie" />
+            <span className="font-mono text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+              Voice
+            </span>
+            <span className="font-mono text-[11px] text-muted-foreground ml-auto">
+              {notes.filter(n => n.type === 'voice').length}
+            </span>
+          </div>
+          {renderKanbanRow('voice')}
+        </section>
+        <div className="h-px bg-border mx-5" />
+        <section className="py-4">
+          <div className="sticky top-0 bg-background z-40 border-b border-border px-5 py-3 flex items-center gap-3">
+            <div className="w-1 h-6 bg-mikey" />
+            <span className="font-mono text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+              Meetings
+            </span>
+            <span className="font-mono text-[11px] text-muted-foreground ml-auto">
+              {notes.filter(n => n.type === 'meeting').length}
+            </span>
+          </div>
+          {renderKanbanRow('meeting')}
+        </section>
+      </div>
+    </>
+  );
+
+  const renderListContent = () => (
+    <div className="flex flex-col h-full">
+      {/* Filters */}
+      <div className="border-b border-border p-3 flex flex-wrap gap-2 items-center">
+        <span className="font-mono text-[10px] text-muted-foreground uppercase tracking-widest mr-2">
+          Filter:
+        </span>
+        
+        {/* Type filter */}
+        <div className="flex border border-border rounded-none overflow-hidden">
+          <button
+            onClick={() => setTypeFilter('all')}
+            className={cn(
+              'px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest transition-colors',
+              typeFilter === 'all' 
+                ? 'bg-foreground text-background' 
+                : 'hover:bg-accent'
+            )}
+          >
+            All
+          </button>
+          <button
+            onClick={() => setTypeFilter('voice')}
+            className={cn(
+              'px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest transition-colors border-l border-border',
+              typeFilter === 'voice' 
+                ? 'bg-donnie text-white' 
+                : 'hover:bg-accent'
+            )}
+          >
+            Voice
+          </button>
+          <button
+            onClick={() => setTypeFilter('meeting')}
+            className={cn(
+              'px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest transition-colors border-l border-border',
+              typeFilter === 'meeting' 
+                ? 'bg-mikey text-white' 
+                : 'hover:bg-accent'
+            )}
+          >
+            Meetings
+          </button>
+        </div>
+
+        {/* Column filter */}
+        <div className="flex border border-border rounded-none overflow-hidden ml-2">
+          <button
+            onClick={() => setColumnFilter('all')}
+            className={cn(
+              'px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest transition-colors',
+              columnFilter === 'all' 
+                ? 'bg-foreground text-background' 
+                : 'hover:bg-accent'
+            )}
+          >
+            All
+          </button>
+          {COLUMNS.map(col => (
+            <button
+              key={col.id}
+              onClick={() => setColumnFilter(col.id)}
+              className={cn(
+                'px-3 py-1.5 font-mono text-[10px] uppercase tracking-widest transition-colors border-l border-border',
+                columnFilter === col.id 
+                  ? 'bg-foreground text-background' 
+                  : 'hover:bg-accent'
+              )}
+            >
+              {col.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto">
+        <NoteList
+          notes={notes}
+          onNoteClick={setSelectedNote}
+          typeFilter={typeFilter}
+          columnFilter={columnFilter}
+        />
+      </div>
+    </div>
+  );
+
+  const content = (
+    <>
+      {/* View Toggle - Fixed position */}
+      <div className="border-b border-border px-4 py-2 flex items-center justify-between bg-card/50">
+        <span className="font-mono text-[10px] text-muted-foreground uppercase tracking-widest">
+          {notes.length} notes
+        </span>
+        <div className="flex border border-border rounded-none overflow-hidden">
+          <button
+            onClick={() => setViewMode('kanban')}
+            className={cn(
+              'p-2 transition-colors',
+              viewMode === 'kanban' 
+                ? 'bg-foreground text-background' 
+                : 'hover:bg-accent'
+            )}
+            title="Kanban view"
+          >
+            <KanbanIcon className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => setViewMode('list')}
+            className={cn(
+              'p-2 transition-colors border-l border-border',
+              viewMode === 'list' 
+                ? 'bg-foreground text-background' 
+                : 'hover:bg-accent'
+            )}
+            title="List view"
+          >
+            <ListIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Main layout */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Main content area */}
+        <main className="flex-1 overflow-hidden">
+          {viewMode === 'kanban' ? renderKanbanContent() : renderListContent()}
+        </main>
+
+        {/* Desktop Sidebar */}
+        <div className="hidden lg:block">
+          <TaskSidebar notes={notes} onToggleAction={handleToggleAction} />
+        </div>
+      </div>
+
+      {/* Mobile: Floating task button + sheet */}
+      <div className="lg:hidden">
+        <Sheet open={taskSheetOpen} onOpenChange={setTaskSheetOpen}>
+          <SheetTrigger asChild>
+            <Button
+              size="lg"
+              className="fixed bottom-6 right-6 h-14 w-14 rounded-none bg-raph hover:bg-raph/90 text-white font-mono text-sm font-bold shadow-lg z-50"
+            >
+              {pendingTaskCount}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="bottom" className="h-[70vh] p-0">
+            <SheetHeader className="p-4 border-b border-border">
+              <SheetTitle className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                Tasks ({pendingTaskCount})
+              </SheetTitle>
+            </SheetHeader>
+            <div className="overflow-y-auto h-[calc(70vh-60px)]">
+              <TaskSidebar notes={notes} onToggleAction={handleToggleAction} embedded />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      {/* Drag overlay (only for kanban) */}
+      {viewMode === 'kanban' && (
+        <DragOverlay>
+          {activeNote && (
+            <div className={cn(
+              'bg-card border border-border p-3 w-[280px] shadow-xl',
+              'border-l-[3px]',
+              activeNote.type === 'voice' ? 'border-l-donnie' : 'border-l-mikey'
+            )}>
+              <h3 className="text-sm font-medium line-clamp-2">{activeNote.title}</h3>
+            </div>
+          )}
+        </DragOverlay>
+      )}
+
+      {/* Note detail modal */}
+      <NoteDetail
+        note={selectedNote}
+        open={!!selectedNote}
+        onClose={() => setSelectedNote(null)}
+        onMove={handleMove}
+        onToggleAction={handleToggleAction}
+      />
+    </>
+  );
+
+  if (embedded) {
+    return (
+      <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="h-full flex flex-col bg-background">
+          {content}
+        </div>
+      </DndContext>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="min-h-screen flex flex-col bg-background">
+        {content}
+      </div>
+    </DndContext>
+  );
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -53,9 +53,9 @@ export const sampleNotes: Note[] = [
     title: 'Testing the New Recording Device Functionality',
     synopsis: 'An exploration of a new recording device to determine if it captures audio continuously or only generates summaries.',
     takeaways: [
-      'The speaker is unsure about the functionality of a new recording device',
-      'The primary question is whether the device records everything continuously or only creates summaries',
-      'A test is being conducted to understand the device behavior'
+      'device-testing',
+      'plaud',
+      'audio'
     ],
     actions: [
       { text: 'Test the mark feature by pushing the button and reviewing the output', done: false },
@@ -63,7 +63,8 @@ export const sampleNotes: Note[] = [
     ],
     transcript: '00:00:28\nSo this is my new recording device that I\'m using right now. And I\'m trying to see if it\'s recording me.\n\n00:00:55\nSo it\'s not going to record every word, I guess. It\'s just going to record highlights about the things that I\'m saying.',
     date: '2026-02-01',
-    column: 'inbox'
+    column: 'inbox',
+    duration: 120
   },
   {
     id: '2',
@@ -71,25 +72,27 @@ export const sampleNotes: Note[] = [
     title: 'Quick idea: Dealership dashboard redesign',
     synopsis: 'Thoughts on simplifying the main dashboard view for dealership managers.',
     takeaways: [
-      'Current dashboard is too cluttered',
-      'Need KPI widgets front and center',
-      'Mobile view needs complete rethink'
+      'dashboard',
+      'ui-design',
+      'dealership'
     ],
     actions: [],
     transcript: '00:00:05\nJust had a thought about the dashboard...',
     date: '2026-01-31',
-    column: 'review'
+    column: 'review',
+    duration: 45
   },
   {
     id: '3',
     type: 'voice',
     title: 'Reminder: Call Brad about data export',
     synopsis: 'Need to follow up with Brad on the GA4 data format.',
-    takeaways: ['Brad prefers CSV over JSON', 'Weekly exports on Mondays'],
+    takeaways: ['ga4', 'data-export', 'brad'],
     actions: [{ text: 'Schedule call with Brad', done: false }],
     transcript: '00:00:02\nDon\'t forget to call Brad...',
     date: '2026-02-02',
-    column: 'action'
+    column: 'action',
+    duration: 30
   },
   {
     id: '4',
@@ -97,9 +100,9 @@ export const sampleNotes: Note[] = [
     title: 'Sam Boswell Q1 Planning Discussion',
     synopsis: 'Quarterly planning meeting with O\'Neil and Brad to discuss marketing strategy and GA4 integration timeline.',
     takeaways: [
-      'GA4 integration is priority for Q1',
-      'Brad will provide historical data by Feb 15',
-      'O\'Neil approved budget for additional rooftop rollout'
+      'q1-planning',
+      'sam-boswell',
+      'ga4'
     ],
     actions: [
       { text: 'Schedule follow-up with Brad on data format', done: false },
@@ -108,7 +111,9 @@ export const sampleNotes: Note[] = [
     ],
     transcript: '00:01:12\nAlright, so let\'s talk about Q1 priorities for Sam Boswell...',
     date: '2026-02-01',
-    column: 'inbox'
+    column: 'inbox',
+    duration: 1800,
+    participants: ['O\'Neil', 'Brad']
   },
   {
     id: '5',
@@ -116,9 +121,9 @@ export const sampleNotes: Note[] = [
     title: 'Vendor call with Analytics provider',
     synopsis: 'Discussion about API limits and pricing tiers for scaled usage.',
     takeaways: [
-      'Current tier allows 10k calls per day',
-      'Enterprise tier needed for multi-rooftop',
-      'They offered 20% discount for annual commit'
+      'vendor',
+      'analytics',
+      'pricing'
     ],
     actions: [
       { text: 'Compare pricing with alternatives', done: false },
@@ -126,7 +131,9 @@ export const sampleNotes: Note[] = [
     ],
     transcript: '00:00:30\nThanks for hopping on this call...',
     date: '2026-01-30',
-    column: 'action'
+    column: 'action',
+    duration: 2400,
+    participants: ['Vendor Rep']
   },
   {
     id: '6',
@@ -134,9 +141,9 @@ export const sampleNotes: Note[] = [
     title: 'Shawn sync: Next Automotive roadmap',
     synopsis: 'Weekly sync with Shawn on consulting pipeline and deliverables.',
     takeaways: [
-      'Two new leads in pipeline',
-      'Sam Boswell expansion on track',
-      'Need to hire contractor for frontend'
+      'weekly-sync',
+      'shawn',
+      'roadmap'
     ],
     actions: [
       { text: 'Review contractor candidates', done: true },
@@ -144,6 +151,8 @@ export const sampleNotes: Note[] = [
     ],
     transcript: '00:00:15\nHey, let\'s go through the week...',
     date: '2026-01-29',
-    column: 'review'
+    column: 'review',
+    duration: 1200,
+    participants: ['Shawn']
   }
 ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type NoteType = 'voice' | 'meeting';
 export type ColumnId = 'inbox' | 'review' | 'action' | 'done';
+export type ViewMode = 'kanban' | 'list';
 
 export interface Action {
   text: string;
@@ -11,11 +12,13 @@ export interface Note {
   type: NoteType;
   title: string;
   synopsis: string;
-  takeaways: string[];
+  takeaways: string[];  // Also serves as tags
   actions: Action[];
   transcript: string;
   date: string;
   column: ColumnId;
+  duration?: number;    // Duration in seconds
+  participants?: string[];  // For meetings
 }
 
 export const COLUMNS: { id: ColumnId; label: string }[] = [


### PR DESCRIPTION
## Summary
Adds list view option and enhances note display with duration, tags, and participants.

## Changes
- Add `ViewMode` type with 'kanban' and 'list' options
- Add `duration` and `participants` fields to Note interface
- Create `NoteList` component with filtering support
- Create `NotesView` component combining kanban and list views
- Add view toggle (kanban/list icons)
- Add type filter (all/voice/meetings) and column filter
- Update `NoteCard` to show duration and tags preview
- Update `NoteDetail` to show duration badge and participants
- Change takeaways display to tags (badges instead of list)
- Update sample data with realistic durations and tags

## Screenshots
The notes view now supports:
- **Kanban view**: Drag-and-drop cards between Inbox → Review → Action → Done columns
- **List view**: Chronological list with filtering by type and status
- **Duration display**: Shows formatted duration (e.g., '30m', '1h 20m') on cards
- **Tags**: Displayed as badges on cards and in detail view

Closes #8