### PR TITLE
Fix: Wire up Activity and Search views with real components

### DIFF
--- a/src/components/mission-control/squad-dashboard.tsx
+++ b/src/components/mission-control/squad-dashboard.tsx
@@ -32,6 +32,30 @@ export function SquadDashboard() {
   const [agentDetail, setAgentDetail] = useState<AgentDetail | null>(null);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [squadViewMode, setSquadViewMode] = useState<SquadViewMode>('overview');
+  
+  // Activity state
+  const [activities, setActivities] = useState<Activity[]>(mockActivity);
+  const [isLoadingActivities, setIsLoadingActivities] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+
+  // Fetch activities from data source
+  const fetchActivities = useCallback(async () => {
+    setIsLoadingActivities(true);
+    try {
+      const data = await dataSource.getActivity();
+      setActivities(data);
+      setLastRefresh(new Date());
+    } catch (error) {
+      console.error('Failed to fetch activities:', error);
+    } finally {
+      setIsLoadingActivities(false);
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchActivities();
+  }, [fetchActivities]);
 
   // Fetch agent detail when an agent is selected
   const fetchAgentDetail = useCallback(async (agent: Agent) => {


### PR DESCRIPTION
## Summary

Fixes the broken views in Command Center that were showing "Coming soon" placeholders instead of the real components.

## Changes

### app-shell.tsx
- **Removed duplicate `AppShell` export** - there were two definitions, now just one clean version
- **ActivityView** - Now uses real `ActivityFeed` component with DataSource fetching
- **SearchView** - Now shows `SearchBar` component (triggers modal on click or ⌘K)  
- **NotesView** - Uses the real `NotesView` instead of non-existent `KanbanBoard`
- **SettingsView** - Kept as placeholder (intentional for now)

### squad-dashboard.tsx
- **Added missing activity state** - `activities`, `isLoadingActivities`, `lastRefresh`
- **Added `fetchActivities`** - Fetches from DataSource on mount and refresh
- This fixes the TypeScript errors from undefined variables

## Testing
- ✅ `npm run build` passes
- Activity tab now shows real activity feed with refresh capability
- Search tab shows search bar (opens modal on click, ⌘K works anywhere)