### PR TITLE
fix(mobile): settings in nav + task button positioning

### DIFF
--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -9,6 +9,7 @@ const navItems: { id: NavView; label: string; icon: string }[] = [
   { id: 'activity', label: 'Activity', icon: '📊' },
   { id: 'memory', label: 'Memory', icon: '🧠' },
   { id: 'search', label: 'Search', icon: '🔍' },
+  { id: 'settings', label: 'Settings', icon: '⚙️' },
 ];
 
 interface MobileNavProps {

--- a/src/components/notes-view.tsx
+++ b/src/components/notes-view.tsx
@@ -356,7 +356,7 @@ export function NotesView({ embedded }: NotesViewProps) {
           <SheetTrigger asChild>
             <Button
               size="lg"
-              className="fixed bottom-6 right-6 h-14 w-14 rounded-none bg-raph hover:bg-raph/90 text-white font-mono text-sm font-bold shadow-lg z-50"
+              className="fixed bottom-20 right-6 h-14 w-14 rounded-none bg-raph hover:bg-raph/90 text-white font-mono text-sm font-bold shadow-lg z-50"
             >
               {pendingTaskCount}
             </Button>


### PR DESCRIPTION
## Fixes

**Issue 1: Settings not accessible on mobile**
- Added settings (⚙️) to mobile-nav.tsx as the 6th nav item
- Mobile nav now has: Notes, Squad, Activity, Memory, Search, Settings

**Issue 2: Floating task button overlaps mobile nav**
- Changed task button position from `bottom-6` to `bottom-20` in notes-view.tsx
- Button now clears the mobile nav bar

## Testing
- Build passes ✓
- Ready for mobile viewport testing