### PR TITLE
fix: mobile nav sheet slides from top

### DIFF
--- a/src/components/mobile-sheet-nav.tsx
+++ b/src/components/mobile-sheet-nav.tsx
@@ -45,7 +45,7 @@ export function MobileSheetNav({ currentView, onViewChange }: MobileSheetNavProp
         <Menu className="w-5 h-5" />
       </button>
 
-      <SheetContent side="bottom" showCloseButton={false} className="rounded-t-2xl pb-8">
+      <SheetContent side="top" showCloseButton={false} className="rounded-b-2xl pt-2">
         <SheetHeader className="pb-2">
           <SheetTitle className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
             Navigation
@@ -80,8 +80,6 @@ export function MobileSheetNav({ currentView, onViewChange }: MobileSheetNavProp
           ))}
         </nav>
 
-        {/* Safe area for home indicator on iOS */}
-        <div className="h-4" />
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
Quick UX fix: hamburger is at top, nav should slide down from top so items are immediately thumb-accessible.

**Changes:**
- `SheetContent side="bottom"` → `side="top"`
- Adjusted border radius (`rounded-b-2xl`)
- Removed iOS home indicator safe area (not needed for top sheet)